### PR TITLE
MooseVariable::getOrder() replaced by MooseVariable::order().

### DIFF
--- a/src/bcs/DGFluxBC.C
+++ b/src/bcs/DGFluxBC.C
@@ -90,7 +90,7 @@ DGFluxBC::computeQpResidual()
 {
 	Real r = 0;
 	
-	const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+	const unsigned int elem_b_order = static_cast<unsigned int> (_var.order());
 	const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 	
 	//Output
@@ -112,7 +112,7 @@ DGFluxBC::computeQpJacobian()
 {
 	Real r = 0;
 	
-	const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+	const unsigned int elem_b_order = static_cast<unsigned int> (_var.order());
 	const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 	
 	//Output

--- a/src/bcs/DGFluxLimitedBC.C
+++ b/src/bcs/DGFluxLimitedBC.C
@@ -94,7 +94,7 @@ DGFluxLimitedBC::computeQpResidual()
 {
 	Real r = 0;
 	
-	const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+	const unsigned int elem_b_order = static_cast<unsigned int> (_var.order());
 	const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 	
 	//Output (Standard Flux Out)
@@ -120,7 +120,7 @@ DGFluxLimitedBC::computeQpJacobian()
 {
 	Real r = 0;
 	
-	const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+	const unsigned int elem_b_order = static_cast<unsigned int> (_var.order());
 	const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 	
 	//Output (Standard Flux Out)

--- a/src/dgkernels/DGAnisotropicDiffusion.C
+++ b/src/dgkernels/DGAnisotropicDiffusion.C
@@ -81,7 +81,7 @@ Real DGAnisotropicDiffusion::computeQpResidual(Moose::DGResidualType type)
 {
 	Real r = 0;
 	
-	const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+	const unsigned int elem_b_order = static_cast<unsigned int> (_var.order());
 	const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 	
 	switch (type)
@@ -108,7 +108,7 @@ Real DGAnisotropicDiffusion::computeQpJacobian(Moose::DGJacobianType type)
 {
 	Real r = 0;
 	
-	const unsigned int elem_b_order = static_cast<unsigned int> (_var.getOrder());
+	const unsigned int elem_b_order = static_cast<unsigned int> (_var.order());
 	const double h_elem = _current_elem->volume()/_current_side_elem->volume() * 1./std::pow(elem_b_order, 2.);
 	
 	switch (type)


### PR DESCRIPTION
Refs idaholab/moose#6377.
